### PR TITLE
dist: include package data when installing from source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     packages=find_packages(),
     entry_points={'console_scripts': ['putiosync=putiosync.frontend:main']},
     install_requires=get_requirements(),
+    include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
The code previously correctly included package data files (e.g. jinja
templates) when a release was made.  Installation on clients, however,
was not unpacking this package data due to the lack of the
`include_package_data` options to `setup()`.

Resolves #20

Signed-off-by: Paul Osborne <osbpau@gmail.com>