### PR TITLE
Torrent watch support

### DIFF
--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 
 
-logging.basicConfig(level=logging.DEBUG,
+logging.basicConfig(level=logging.WARN,
                     format='%(asctime)s | %(name)-12s | %(levelname)-8s | %(message)s')
 logger = logging.getLogger("putiosync")
 

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 
 
-logging.basicConfig(level=logging.WARN,
+logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s | %(name)-12s | %(levelname)-8s | %(message)s')
 logger = logging.getLogger("putiosync")
 

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -93,11 +93,10 @@ class TokenManager(object):
 class PutioSynchronizer(object):
     """Object encapsulating core synchronization logic and state"""
 
-    def __init__(self, token, download_directory, db_manager, download_manager, keep_files=False, poll_frequency=60):
-        self._token = token
+    def __init__(self, download_directory, putio_client, db_manager, download_manager, keep_files=False, poll_frequency=60):
+        self._putio_client = putio_client
         self._download_directory = download_directory
         self._db_manager = db_manager
-        self._putio_client = putio.Client(token)
         self._poll_frequency = poll_frequency
         self._keep_files = keep_files
         self._download_manager = download_manager

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -101,6 +101,9 @@ class PutioSynchronizer(object):
         self._keep_files = keep_files
         self._download_manager = download_manager
 
+    def get_download_directory(self):
+        return self._download_directory
+
     def _is_directory(self, putio_file):
         return (putio_file.content_type == 'application/x-directory')
 

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -98,7 +98,7 @@ def main():
     t = threading.Thread(target=synchronizer.run_forever)
     t.setDaemon(True)
     t.start()
-    web_interface = WebInterface(db_manager, download_manager, putio_client, synchronizer
+    web_interface = WebInterface(db_manager, download_manager, putio_client, synchronizer)
     web_interface.run()
     return 0
 

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -98,7 +98,7 @@ def main():
     t = threading.Thread(target=synchronizer.run_forever)
     t.setDaemon(True)
     t.start()
-    web_interface = WebInterface(db_manager, download_manager)
+    web_interface = WebInterface(db_manager, download_manager, putio_client, synchronizer
     web_interface.run()
     return 0
 

--- a/putiosync/watcher.py
+++ b/putiosync/watcher.py
@@ -1,0 +1,55 @@
+import logging
+import time
+import os
+
+from watchdog.observers import Observer
+from watchdog.events import LoggingEventHandler, FileSystemEventHandler
+
+logger = logging.getLogger(__name__)
+
+
+def is_torrent(ext):
+    return ext in (".torrent", ".magnet")
+
+
+class TorrentWatcherFilesystemEventHandler(FileSystemEventHandler):
+    """This class handles filesystem changes to monitored directories
+
+    This will filter events and queue up torrents to be downloaded
+    if a new torrent or magnet file is added to the monitored directories.
+
+    """
+
+    def __init__(self, putio_client):
+        FileSystemEventHandler.__init__(self)
+        self._putio_client = putio_client
+
+    def on_created(self, event):
+        if not event.is_directory:
+            basename = os.path.basename(event.src_path)
+            _name, ext = os.path.splitext(basename)
+            if is_torrent(ext):
+                logger.info("Adding torrent from path '%s'", event.src_path)
+                self._putio_client.Transfer.add_torrent(event.src_path)
+
+
+class TorrentWatcher(object):
+
+    def __init__(self, watch_directory, putio_client):
+        self._watch_directory = watch_directory
+        self._putio_client = putio_client
+        self._observer = Observer()
+        self._event_handler = TorrentWatcherFilesystemEventHandler(self._putio_client)
+
+    def stop(self):
+        self._observer.stop()
+
+    def join(self, *args, **kwargs):
+        self._observer.join(*args, **kwargs)
+
+    def start(self):
+        # TODO: add recursive option in future
+        self._observer.schedule(self._event_handler,
+                                self._watch_directory,
+                                recursive=False)
+        self._observer.start()

--- a/putiosync/watcher.py
+++ b/putiosync/watcher.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import os
 
 from watchdog.observers import Observer

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -1,0 +1,61 @@
+import json
+import logging
+import flask
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class TransmissionRPCServer(object):
+
+    def __init__(self, putio_client):
+        self._putio_client = putio_client
+        self.methods = {
+            "session-get": self._session_get,
+            "torrent-get": self._torrent_get,
+            "torrent-add": self._torrent_add,
+        }
+
+    def _session_get(self):
+        # Many more are supported by real client, this is enough for Sonarr
+        return {
+            "rpc-version": 15,
+            "version": "2.84 (putiosync)",
+        }
+
+    def _torrent_add(self, filename):
+        if os.path.isfile(filename):
+            self._putio_client.Transfer.add_torrent(filename)
+        else:
+            self._putio_client.Transfer.add_url(filename)
+        return {}
+
+    def _torrent_get(self, fields):
+        return {"torrents": []}
+
+    def handle_request(self):
+        data = json.loads(flask.request.data)
+        method = data['method']
+        arguments = data.get('arguments', {})
+        tag = data.get('tag')
+        logger.info("Method: %r, Arguments: %r", method, arguments)
+        logger.info("%r", flask.request.headers)
+        try:
+            result = self.methods[method](**arguments)
+        except Exception, e:
+            response = {
+                "result": "error",
+                "error_description": "%s" % e,
+            }
+        else:
+            response = {
+                "result": "success",
+                "arguments": result,
+            }
+
+        if tag:
+            response["tag"] = tag
+
+        res = flask.make_response(json.dumps(response))
+        res.headers['X-Transmission-Session-Id'] = '1234'  # TODO: X-Transmission-Session-Id
+        return res

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -1,15 +1,111 @@
 import json
 import logging
+import uuid
 import flask
 import os
+
 
 logger = logging.getLogger(__name__)
 
 
-class TransmissionRPCServer(object):
+def map_status(status):
+    return {
+        "IN_QUEUE": 3,  # queued
+        "DOWNLOADING": 4,  # downloading
+        "COMPLETED": 6,  # seeding
+    }.get(status, 3)  # default: queued
 
-    def __init__(self, putio_client):
+
+class TransmissionTransferProxy(object):
+    """Wrap a put.io transfer and map to Transmission torrent iface
+
+    Here's an example of the information we get from Put.io for a transfer:
+
+        {
+            "availability": null,
+            "callback_url": null,
+            "client_ip": null,
+            "created_at": "2015-10-13T05:20:22",
+            "created_torrent": false,
+            "current_ratio": "0.00",
+            "down_speed": 0,
+            "download_id": 17654355,
+            "downloaded": 0,
+            "error_message": null,
+            "estimated_time": null,
+            "extract": false,
+            "file_id": 313672617,
+            "finished_at": "2015-10-13T05:20:24",
+            "id": 30210267,
+            "is_private": false,
+            "magneturi": "magnet:?xt=urn:btih:9ce5e6fc6aa605287c8e2af20c01c5655ff59074&dn=Fargo+S02E01+720p+HDTV+x264+KILLERS",
+            "name": "Fargo S02E01 720p HDTV x264 KILLERS",
+            "peers_connected": 0,
+            "peers_getting_from_us": 0,
+            "peers_sending_to_us": 0,
+            "percent_done": 100,
+            "save_parent_id": 0,
+            "seconds_seeding": 0,
+            "size": 935982427,
+            "source": "magnet:?xt=urn:btih:9CE5E6FC6AA605287C8E2AF20C01C5655FF59074&dn=Fargo+S02E01+720p+HDTV+x264+KILLERS&tr=udp://tracker.coppersurfer.tk:6969/announce&tr=udp://tracker.leechers-paradise.org:6969&tr=udp://open.demonii.com:1337",
+            "status": "COMPLETED",
+            "status_message": "Completed 5 days ago.",
+            "subscription_id": 4895894,
+            "torrent_link": "/v2/transfers/30210267/torrent",
+            "tracker_message": null,
+            "trackers": null,
+            "type": "TORRENT",
+            "up_speed": 0,
+            "uploaded": 0
+        },
+
+    """
+
+    def __init__(self, putio_transfer, synchronizer):
+        self.synchronizer = synchronizer
+        self.transfer = putio_transfer
+        # sonar requests the following:
+        # - id
+        # - hashString
+        # - name
+        # - downloadDir
+        # - status
+        # - totalSize
+        # - leftUntilDone
+        # - eta
+        # - errorString
+        self._field_providers = {
+            "id": lambda: self.transfer.id,
+            "hashString": lambda: "%s" % self.transfer.id,
+            "name": lambda: self.transfer.name,
+            "downloadDir": lambda: self.synchronizer.get_download_directory(),
+            "status": lambda: map_status(self.transfer.status),
+            "totalSize": lambda: self.transfer.size,
+            "leftUntilDone": lambda: self.transfer.size - self.transfer.downloaded,
+            "errorString": lambda: self.transfer.errorMessage,
+        }
+
+    def render_json(self, fields):
+        return {f: self._field_providers.get(f, lambda: None) for f in fields}
+
+
+class TransmissionRPCServer(object):
+    """Expose a JSON-RPC interface attempting to match Transmission
+
+    This API interface is documented at
+    https://trac.transmissionbt.com/browser/trunk/extras/rpc-spec.txt.  We attempt
+    to match enough so that we can get integration from clients of the transmission
+    API (e.g. Sonarr) without having to modify those pieces of software directly.
+
+    The implementation is (and probably always will be) partial and your results
+    may vary from client to client depending on how much, how little they expect
+    to have implemented.
+    """
+
+    def __init__(self, putio_client, synchronizer):
+        self._synchronizer = synchronizer
         self._putio_client = putio_client
+        self._session_id = str(uuid.uuid1())
         self.methods = {
             "session-get": self._session_get,
             "torrent-get": self._torrent_get,
@@ -31,31 +127,39 @@ class TransmissionRPCServer(object):
         return {}
 
     def _torrent_get(self, fields):
-        return {"torrents": []}
+        transfers = self._putio_client.Transfer.list()
+        transmission_transfers = [TransmissionTransferProxy(t, self._synchronizer) for t in transfers]
+        return {"torrents": [t.render_json(fields) for t in transmission_transfers]}
 
     def handle_request(self):
-        data = json.loads(flask.request.data)
-        method = data['method']
-        arguments = data.get('arguments', {})
-        tag = data.get('tag')
-        logger.info("Method: %r, Arguments: %r", method, arguments)
-        logger.info("%r", flask.request.headers)
-        try:
-            result = self.methods[method](**arguments)
-        except Exception, e:
-            response = {
-                "result": "error",
-                "error_description": "%s" % e,
-            }
+        # If GET, just provide X-Transmission-Session-Id with HTTP 409
+        if flask.request.method == "GET":
+            res = flask.make_response("Session ID: %s" % self._session_id)
+            res.headers['X-Transmission-Session-Id'] = self._session_id
+            return res, 409
         else:
-            response = {
-                "result": "success",
-                "arguments": result,
-            }
+            data = json.loads(flask.request.data)
+            method = data['method']
+            arguments = data.get('arguments', {})
+            tag = data.get('tag')
+            logger.info("Method: %r, Arguments: %r", method, arguments)
+            logger.info("%r", flask.request.headers)
+            try:
+                result = self.methods[method](**arguments)
+            except Exception, e:
+                response = {
+                    "result": "error",
+                    "error_description": "%s" % e,
+                }
+            else:
+                response = {
+                    "result": "success",
+                    "arguments": result,
+                }
 
-        if tag:
-            response["tag"] = tag
+            if tag:
+                response["tag"] = tag
 
-        res = flask.make_response(json.dumps(response))
-        res.headers['X-Transmission-Session-Id'] = '1234'  # TODO: X-Transmission-Session-Id
-        return res
+            res = flask.make_response(json.dumps(response))
+            res.headers['X-Transmission-Session-Id'] = self._session_id
+            return res

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -86,7 +86,7 @@ class TransmissionTransferProxy(object):
         }
 
     def render_json(self, fields):
-        return {f: self._field_providers.get(f, lambda: None) for f in fields}
+        return {f: self._field_providers.get(f, lambda: None)() for f in fields}
 
 
 class TransmissionRPCServer(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sqlalchemy==0.9.1
 flask==0.10.1
 flask-restless==0.12.1
 flask-restful==0.2.11
+watchdog==0.8.3


### PR DESCRIPTION
These changes add basic support for watching a directory for torrents and implementing a basic subset of the transmission RPC interface that has been tested to work pretty well with current releases of Sonarr.