### PR TITLE
Fix #27 by tweaking Transmission RPC support

### DIFF
--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -114,6 +114,9 @@ class PutioSynchronizer(object):
         matching_rec_exists = self._db_manager.get_db_session().query(exists().where(DownloadRecord.file_id == putio_file.id)).scalar()
         return matching_rec_exists
 
+    def isAlreadyDownloaded(self, putio_file):
+        return self._already_downloaded(putio_file, self._download_directory)
+
     def _record_downloaded(self, putio_file):
         filename = putio_file.name.encode('ascii', 'ignore')
         matching_rec_exists = self._db_manager.get_db_session().query(exists().where(DownloadRecord.file_id == putio_file.id)).scalar()
@@ -206,4 +209,3 @@ class PutioSynchronizer(object):
             time_since_last_check = datetime.datetime.now() - last_check
             if time_since_last_check < datetime.timedelta(seconds=self._poll_frequency):
                 time.sleep(self._poll_frequency - time_since_last_check.total_seconds())
-

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -84,7 +84,7 @@ class TransmissionTransferProxy(object):
             "leftUntilDone": lambda: self.transfer.size - self.transfer.downloaded,
             "errorString": lambda : '' if self.transfer.error_message is None else self.transfer.error_message,
             "isFinished": lambda : 1 if self.transfer.downloaded == 1 else False,
-            "eta": lambda : -1 if self.transfer.estimated_time is None else self.transfer.estimated_time
+            "eta": lambda : 0 if self.transfer.estimated_time is None else self.transfer.estimated_time
         }
 
     def render_json(self, fields):

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -15,6 +15,14 @@ def map_status(status):
         "COMPLETED": 6,  # seeding
     }.get(status, 3)  # default: queued
 
+def geteta(eta):
+    if eta is None:
+        return 0
+    else:
+        if eta < 0:
+            return 0
+        else:
+            return eta
 
 class TransmissionTransferProxy(object):
     """Wrap a put.io transfer and map to Transmission torrent iface
@@ -84,7 +92,7 @@ class TransmissionTransferProxy(object):
             "leftUntilDone": lambda: self.transfer.size - self.transfer.downloaded,
             "errorString": lambda : '' if self.transfer.error_message is None else self.transfer.error_message,
             "isFinished": lambda : 1 if self.transfer.downloaded == 1 else False,
-            "eta": lambda : 0 if self.transfer.estimated_time is None else self.transfer.estimated_time
+            "eta": lambda : geteta(self.transfer.estimated_time)
         }
 
     def render_json(self, fields):

--- a/putiosync/webif/transmissionrpc.py
+++ b/putiosync/webif/transmissionrpc.py
@@ -82,7 +82,9 @@ class TransmissionTransferProxy(object):
             "status": lambda: map_status(self.transfer.status),
             "totalSize": lambda: self.transfer.size,
             "leftUntilDone": lambda: self.transfer.size - self.transfer.downloaded,
-            "errorString": lambda: self.transfer.errorMessage,
+            "errorString": lambda : '' if self.transfer.error_message is None else self.transfer.error_message,
+            "isFinished": lambda : 1 if self.transfer.downloaded == 1 else False,
+            "eta": lambda : -1 if self.transfer.estimated_time is None else self.transfer.estimated_time
         }
 
     def render_json(self, fields):


### PR DESCRIPTION
This PR is geared towards Transmission RPC masquerading, as mentioned in #27.

I can't take credit for this: @cedbossneo (who for some weird reason I've been calling "@chauber") wrote this code. I simply went through his changes and cherry-picked the stuff that would fix the problem, and tidy up some other issues.

It fixes the following issues:

- reports when a torrent is finished downloading
- tidies up torrent eta reporting
- uses a zero-length errorString when there is no error (instead of null)
- Sonarr not recognizing putio-sync a Transmission

This PR changes the way that requests are handled, passing the entire RPC `arguments` hash through to the method handler. This, and the other tweaks above, seem to make Sonarr happy.

Before these changes, this command:

```
curl -H "Content-Type: application/json" -X POST -d '{"method":"torrent-get", "arguments":{"fields": ["id","hashString","name","downloadDir","status","totalSize","leftUntilDone","isFinished","eta","errorString"]}}' http://127.0.0.1:7001/transmission/rpc
```

Would return 

```
{"error_description": "'Transfer' object has no attribute 'errorMessage'", "result": "error"}
```

Now, after these changes, we get:

```
{"result": "success", "arguments": {"torrents": [{"status": 3, "name": "...", "downloadDir": "/media/sf_put-io/download/", "totalSize": ..., "hashString": "...", "errorString": "", "isFinished": false, "eta": 0, "leftUntilDone": 0, "id": ...}, {"status": 4, "name": "...", "downloadDir": "/media/sf_put-io/download/", "totalSize": ..., "hashString": "...", "errorString": "", "isFinished": false, "eta": 0, "leftUntilDone": 188884863, "id": ...}]}}
```

(the `...` are where I've removed irrelevant information).