### PR TITLE
Allow changing host and port for webinterface

### DIFF
--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -54,6 +54,18 @@ def parse_arguments():
         )
     )
     parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        type=str,
+        help="Host where the webserver should listen to. Default: 0.0.0.0"
+    )
+    parser.add_argument(
+        "--port",
+        default="7001",
+        type=str,
+        help="Port where the webserver should listen to. Default: 7001"
+    )
+    parser.add_argument(
         "download_directory",
         help="Directory into which files should be downloaded"
     )
@@ -104,7 +116,7 @@ def main():
     t = threading.Thread(target=synchronizer.run_forever)
     t.setDaemon(True)
     t.start()
-    web_interface = WebInterface(db_manager, download_manager, putio_client, synchronizer, launch_browser=(not args.quiet))
+    web_interface = WebInterface(db_manager, download_manager, putio_client, synchronizer, launch_browser=(not args.quiet), host=args.host, port=args.port)
     web_interface.run()
     return 0
 

--- a/putiosync/webif/webif.py
+++ b/putiosync/webif/webif.py
@@ -10,9 +10,6 @@ from flask import render_template
 from putiosync.webif.transmissionrpc import TransmissionRPCServer
 from sqlalchemy import desc, func
 
-APPLICATION_HOST = "0.0.0.0"
-APPLICATION_PORT = 7001  # avoid conflict with default flask port
-
 logger = logging.getLogger("putiosync.webif")
 
 
@@ -96,7 +93,8 @@ class DownloadRateTracker(object):
 
 
 class WebInterface(object):
-    def __init__(self, db_manager, download_manager, putio_client, synchronizer, launch_browser=False):
+    def __init__(self, db_manager, download_manager, putio_client, synchronizer, launch_browser=False, host="0.0.0.0",
+                 port=7001):
         self.app = flask.Flask(__name__)
         self.synchronizer = synchronizer
         self.db_manager = db_manager
@@ -105,6 +103,8 @@ class WebInterface(object):
         self.putio_client = putio_client
         self.transmission_rpc_server = TransmissionRPCServer(putio_client, self.synchronizer)
         self.launch_browser = launch_browser
+        self._host = host
+        self._port = port
         self._rate_tracker = DownloadRateTracker()
 
         self.app.logger.setLevel(logging.DEBUG)
@@ -194,5 +194,5 @@ class WebInterface(object):
     def run(self):
         if self.launch_browser:
             import webbrowser
-            webbrowser.open("http://localhost:{}/".format(APPLICATION_PORT))
-        self.app.run(APPLICATION_HOST, APPLICATION_PORT)
+            webbrowser.open("http://localhost:{}/".format(self._port))
+        self.app.run(self._host, self._port)


### PR DESCRIPTION
By default it listens to 0.0.0.0 which may be too open. E.g. now you can set it to 127.0.0.1 so only the local pc can access the web interface.