### PR TITLE
Fixed ASCII encoding errors by using UTF-8 encoding

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include requirements.txt
 include LICENSE
-recursive-include putiosync/webif/static *.html *.css *.js
+recursive-include putiosync/webif/static *.html *.css *.js *.png
 recursive-include putiosync/webif/templates *.html

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -17,7 +17,6 @@ import sys
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm.session import sessionmaker
-sys.setdefaultencoding('utf-8')
 
 
 logger = logging.getLogger("putiosync")

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -213,9 +213,11 @@ class PutioSynchronizer(object):
             children = putio_file.dir()
             if not children:
                 # this is a directory with no children, it must be destroyed
+                logger.error("Directory with no children")
                 if self.force_keep is None or self.force_keep.match(full_path) is None:
                     putio_file.delete()
             else:
+                logger.error("Directory with children")
                 for child in children:
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -229,7 +229,7 @@ class PutioSynchronizer(object):
                 self._queue_download(putio_file)
         except Exception as ex:
             logger.error("Unexpected error while performing check/download: {}".format(ex))
-            logger.error("File checked: {}".format(putio_file))
+            logger.error("File checked: {}".format(putio_file.name.encode('utf-8','ignore')))
 
     def _wait_until_downloads_complete(self):
         while not self._download_manager.is_empty():

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -220,7 +220,7 @@ class PutioSynchronizer(object):
             else:
                 logger.error("Directory with children")
                 for child in children:
-                    self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
+                    self._queue_download(child, os.path.join(relpath, putio_file.name.encode('utf-8','ignore')), level + 1)
 
     def _perform_single_check(self):
         try:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -220,7 +220,7 @@ class PutioSynchronizer(object):
             else:
                 logger.error("Directory with children")
                 for child in children:
-                    logger.error("Queuing child file: {}".format(child.name))
+                    logger.error("Queuing child file: {}".format(child.name.encode('utf-8','ignore')))
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -131,7 +131,7 @@ class PutioSynchronizer(object):
                 file_id=putio_file.id,
                 size=putio_file.size,
                 timestamp=datetime.datetime.now(),
-                name=filename)
+                name=filename.decode('utf-8'))
             self._db_manager.get_db_session().add(download_record)
             self._db_manager.get_db_session().commit()
         else:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -17,6 +17,8 @@ import sys
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm.session import sessionmaker
+sys.setdefaultencoding('utf-8')
+
 
 logger = logging.getLogger("putiosync")
 

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -215,6 +215,7 @@ class PutioSynchronizer(object):
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):
+        logger.error("File to check: {}".format(self))
         try:
             # Perform a single check for updated files to download
             for putio_file in self._putio_client.File.list():

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -197,9 +197,9 @@ class PutioSynchronizer(object):
         # add this file (or files in this directory) to the queue
 
         full_path = os.path.sep + os.path.join(relpath, putio_file.name)
-        logger.error("File path: {}".format(full_path))
+        logger.error("File path: {}".format(full_path.name.encode('utf-8','ignore')))
         full_path = full_path.replace("\\", "/")
-        logger.error("File path after replace: {}".format(full_path))
+        logger.error("File path after replace: {}".format(full_path.encode('utf-8','ignore')))
         if not self._is_directory(putio_file):
             logger.error("Its a file!")
             if self.download_filter is not None and self.download_filter.match(full_path) is None:
@@ -221,7 +221,7 @@ class PutioSynchronizer(object):
                 logger.error("Directory with children")
                 for child in children:
                     logger.error("Queuing child file: {}".format(child.name.encode('utf-8','ignore')))
-                    self._queue_download(child, os.path.join(relpath, putio_file.name.encode('utf-8','ignore')), level + 1)
+                    self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):
         try:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -221,7 +221,7 @@ class PutioSynchronizer(object):
                 logger.error("Directory with children")
                 for child in children:
                     logger.error("Queuing child file: {}".format(child.name.encode('utf-8','ignore')))
-                    self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
+                    self._queue_download(child, os.path.join(relpath, putio_file.name.encode('utf-8','ignore')), level + 1)
 
     def _perform_single_check(self):
         try:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -219,6 +219,7 @@ class PutioSynchronizer(object):
             else:
                 logger.error("Directory with children")
                 for child in children:
+                    logger.error("Queuing child file: {}".format(child.name))
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -221,7 +221,7 @@ class PutioSynchronizer(object):
                 self._queue_download(putio_file)
         except Exception as ex:
             logger.error("Unexpected error while performing check/download: {}".format(ex))
-            logger.error("File checked: {}".format(self))
+            logger.error("File checked: {}".format(putio_file))
 
     def _wait_until_downloads_complete(self):
         while not self._download_manager.is_empty():

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -112,6 +112,8 @@ class PutioSynchronizer(object):
 
     def _already_downloaded(self, putio_file, dest):
         filename = putio_file.name.encode('ascii', 'ignore')
+        logger.warn("File name check: %r", putio_file.name)
+
         if os.path.exists(os.path.join(dest, "{}".format(filename))):
             return True  # TODO: check size and/or crc32 checksum?
         matching_rec_exists = self._db_manager.get_db_session().query(exists().where(DownloadRecord.file_id == putio_file.id)).scalar()

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -215,13 +215,13 @@ class PutioSynchronizer(object):
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):
-        logger.error("File to check: {}".format(self))
         try:
             # Perform a single check for updated files to download
             for putio_file in self._putio_client.File.list():
                 self._queue_download(putio_file)
         except Exception as ex:
             logger.error("Unexpected error while performing check/download: {}".format(ex))
+            logger.error("File checked: {}".format(self))
 
     def _wait_until_downloads_complete(self):
         while not self._download_manager.is_empty():

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -123,7 +123,7 @@ class PutioSynchronizer(object):
         return self._already_downloaded(putio_file, self._download_directory)
 
     def _record_downloaded(self, putio_file):
-        filename = putio_file.name.encode('ascii', 'ignore')
+        filename = putio_file.name.encode('utf-8', 'ignore')
         matching_rec_exists = self._db_manager.get_db_session().query(exists().where(DownloadRecord.file_id == putio_file.id)).scalar()
         if not matching_rec_exists:
             download_record = DownloadRecord(

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -169,7 +169,7 @@ class PutioSynchronizer(object):
             def completion_callback(_download):
                 # and write a record of the download to the database
                 self._record_downloaded(putio_file)
-                logger.info("Download finished: {}".format(putio_file.name))
+                logger.info("Download finished: {}".format(putio_file.name.encode('utf-8','ignore')))
                 if delete_after_download:
                     try:
                         putio_file.delete()
@@ -183,7 +183,7 @@ class PutioSynchronizer(object):
             download.add_completion_callback(completion_callback)
             self._download_manager.add_download(download)
         else:
-            logger.debug("Already downloaded: '{}'".format(putio_file.name))
+            logger.debug("Already downloaded: '{}'".format(putio_file.name.encode('utf-8','ignore')))
             if delete_after_download:
                 try:
                     putio_file.delete()
@@ -197,9 +197,7 @@ class PutioSynchronizer(object):
         # add this file (or files in this directory) to the queue
 
         full_path = os.path.sep + os.path.join(relpath, putio_file.name.encode('utf-8','ignore'))
-        logger.error("File path: {}".format(full_path))
         full_path = full_path.replace("\\", "/")
-        logger.error("File path after replace: {}".format(full_path))
         if not self._is_directory(putio_file):
             logger.error("Its a file!")
             if self.download_filter is not None and self.download_filter.match(full_path) is None:
@@ -210,15 +208,12 @@ class PutioSynchronizer(object):
                 delete_file = not self._keep_files and (self.force_keep is None or  self.force_keep.match(full_path) is None)
                 self._do_queue_download(putio_file, target_dir, delete_after_download=delete_file)
         else:
-            logger.error("Its a folder!")
             children = putio_file.dir()
             if not children:
                 # this is a directory with no children, it must be destroyed
-                logger.error("Directory with no children")
                 if self.force_keep is None or self.force_keep.match(full_path) is None:
                     putio_file.delete()
             else:
-                logger.error("Directory with children")
                 for child in children:
                     self._queue_download(child, os.path.join(relpath, putio_file.name.encode('utf-8','ignore')), level + 1)
 

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -194,6 +194,7 @@ class PutioSynchronizer(object):
         # add this file (or files in this directory) to the queue
 
         full_path = os.path.sep + os.path.join(relpath, putio_file.name)
+        logger.error("File path: {}".format(full_path))
         full_path = full_path.replace("\\", "/")
         if not self._is_directory(putio_file):
             if self.download_filter is not None and self.download_filter.match(full_path) is None:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -113,7 +113,7 @@ class PutioSynchronizer(object):
 
     def _already_downloaded(self, putio_file, dest):
         filename = putio_file.name.encode('utf-8', 'ignore')
-        logger.warn("File name check: %r", putio_file.name)
+        logger.warn("File name check: %r", putio_file.name.encode('utf-8','ignore'))
 
         if os.path.exists(os.path.join(dest, "{}".format(filename))):
             return True  # TODO: check size and/or crc32 checksum?
@@ -196,7 +196,7 @@ class PutioSynchronizer(object):
     def _queue_download(self, putio_file, relpath="", level=0):
         # add this file (or files in this directory) to the queue
 
-        full_path = os.path.sep + os.path.join(relpath, putio_file.name)
+        full_path = os.path.sep + os.path.join(relpath, putio_file.name.encode('utf-8','ignore'))
         logger.error("File path: {}".format(full_path))
         full_path = full_path.replace("\\", "/")
         logger.error("File path after replace: {}".format(full_path))

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -111,7 +111,7 @@ class PutioSynchronizer(object):
         return (putio_file.content_type == 'application/x-directory')
 
     def _already_downloaded(self, putio_file, dest):
-        filename = putio_file.name.encode('ascii', 'ignore')
+        filename = putio_file.name.encode('utf-8', 'ignore')
         logger.warn("File name check: %r", putio_file.name)
 
         if os.path.exists(os.path.join(dest, "{}".format(filename))):

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -199,7 +199,6 @@ class PutioSynchronizer(object):
         full_path = os.path.sep + os.path.join(relpath, putio_file.name.encode('utf-8','ignore'))
         full_path = full_path.replace("\\", "/")
         if not self._is_directory(putio_file):
-            logger.error("Its a file!")
             if self.download_filter is not None and self.download_filter.match(full_path) is None:
                 logger.debug("Skipping '{0}' because it does not match the provided filter".format(full_path))
             else:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -197,9 +197,9 @@ class PutioSynchronizer(object):
         # add this file (or files in this directory) to the queue
 
         full_path = os.path.sep + os.path.join(relpath, putio_file.name)
-        logger.error("File path: {}".format(full_path.name.encode('utf-8','ignore')))
+        logger.error("File path: {}".format(full_path.name))
         full_path = full_path.replace("\\", "/")
-        logger.error("File path after replace: {}".format(full_path.encode('utf-8','ignore')))
+        logger.error("File path after replace: {}".format(full_path))
         if not self._is_directory(putio_file):
             logger.error("Its a file!")
             if self.download_filter is not None and self.download_filter.match(full_path) is None:

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -200,6 +200,7 @@ class PutioSynchronizer(object):
         full_path = full_path.replace("\\", "/")
         logger.error("File path after replace: {}".format(full_path))
         if not self._is_directory(putio_file):
+            logger.error("Its a file!")
             if self.download_filter is not None and self.download_filter.match(full_path) is None:
                 logger.debug("Skipping '{0}' because it does not match the provided filter".format(full_path))
             else:
@@ -208,6 +209,7 @@ class PutioSynchronizer(object):
                 delete_file = not self._keep_files and (self.force_keep is None or  self.force_keep.match(full_path) is None)
                 self._do_queue_download(putio_file, target_dir, delete_after_download=delete_file)
         else:
+            logger.error("Its a folder!")
             children = putio_file.dir()
             if not children:
                 # this is a directory with no children, it must be destroyed

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -197,7 +197,7 @@ class PutioSynchronizer(object):
         # add this file (or files in this directory) to the queue
 
         full_path = os.path.sep + os.path.join(relpath, putio_file.name)
-        logger.error("File path: {}".format(full_path.name))
+        logger.error("File path: {}".format(full_path))
         full_path = full_path.replace("\\", "/")
         logger.error("File path after replace: {}".format(full_path))
         if not self._is_directory(putio_file):
@@ -220,7 +220,6 @@ class PutioSynchronizer(object):
             else:
                 logger.error("Directory with children")
                 for child in children:
-                    logger.error("Queuing child file: {}".format(child.name.encode('utf-8','ignore')))
                     self._queue_download(child, os.path.join(relpath, putio_file.name), level + 1)
 
     def _perform_single_check(self):

--- a/putiosync/core.py
+++ b/putiosync/core.py
@@ -198,6 +198,7 @@ class PutioSynchronizer(object):
         full_path = os.path.sep + os.path.join(relpath, putio_file.name)
         logger.error("File path: {}".format(full_path))
         full_path = full_path.replace("\\", "/")
+        logger.error("File path after replace: {}".format(full_path))
         if not self._is_directory(putio_file):
             if self.download_filter is not None and self.download_filter.match(full_path) is None:
                 logger.debug("Skipping '{0}' because it does not match the provided filter".format(full_path))

--- a/putiosync/download_manager.py
+++ b/putiosync/download_manager.py
@@ -96,7 +96,7 @@ class Download(object):
         dest = self.get_destination_directory()
         filename = self.get_filename()
 
-        final_path = os.path.join(dest, filename).encode('utf-8')
+        final_path = os.path.join(dest, filename.decode('utf-8'))
         download_path = "{}.part".format(final_path)
 
         # ensure the path into which the download is going to be donwloaded exists. We know

--- a/putiosync/download_manager.py
+++ b/putiosync/download_manager.py
@@ -97,7 +97,7 @@ class Download(object):
         filename = self.get_filename()
 
         final_path = os.path.join(dest, filename.decode('utf-8'))
-        download_path = "{}.part".format(final_path)
+        download_path = "{}.part".format(final_path.encode('utf-8'))
 
         # ensure the path into which the download is going to be donwloaded exists. We know
         # that the 'dest' directory exists but in some cases the filename on put.io may

--- a/putiosync/download_manager.py
+++ b/putiosync/download_manager.py
@@ -39,7 +39,7 @@ class Download(object):
         return self._destination_directory
 
     def get_filename(self):
-        return self.get_putio_file().name.encode('ascii', 'ignore')
+        return self.get_putio_file().name.encode('utf-8', 'ignore')
 
     def get_destination_path(self):
         return os.path.join(os.path.abspath(self._destination_directory),

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -15,7 +15,7 @@ from putiosync.webif.webif import WebInterface
 __author__ = 'Paul Osborne'
 
 logger = logging.getLogger("putiosync")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.ERROR)
 
 
 def parse_arguments():

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -15,7 +15,7 @@ from putiosync.webif.webif import WebInterface
 __author__ = 'Paul Osborne'
 
 logger = logging.getLogger("putiosync")
-logger.setLevel(logging.ERROR)
+logger.setLevel(logging.DEBUG)
 
 
 def parse_arguments():

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -15,7 +15,7 @@ from putiosync.webif.webif import WebInterface
 __author__ = 'Paul Osborne'
 
 logger = logging.getLogger("putiosync")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.ERROR)
 
 
 def parse_arguments():
@@ -168,6 +168,7 @@ def start_sync(args):
 
     log_webif = logging.getLogger('werkzeug')
     log_webif.setLevel(log_level)
+    log_webif.disabled = True
 
     if args.log_webif is not None:
         fh = logging.FileHandler(args.log_webif)

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -126,7 +126,7 @@ def parse_arguments():
 
 def build_postprocess_download_completion_callback(postprocess_command):
     def download_completed(download):
-        cmd=postprocess_command.format(download.get_destination_path().encode('ascii'))
+        cmd=postprocess_command.format(download.get_destination_path().encode('utf-8'))
         logger.info("Postprocess: {0}".format(cmd))
         subprocess.call(cmd, shell=True)
 

--- a/putiosync/frontend.py
+++ b/putiosync/frontend.py
@@ -136,7 +136,7 @@ def start_sync(args):
 
     formatter = logging.Formatter('%(asctime)s | %(name)-12s | %(levelname)-8s | %(message)s')
 
-    log_level = logging.DEBUG
+    log_level = logging.ERROR
     if args.log_level is not None:
         if args.log_level == "debug":
             log_level = logging.DEBUG

--- a/putiosync/webif/templates/base.html
+++ b/putiosync/webif/templates/base.html
@@ -10,8 +10,10 @@
     <link href="/static/css/bootstrap.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
+    <!--
     <link href="/static/css/style.css" rel="stylesheet">
-
+    -->
+    
     <!-- Just for debugging purposes. Don't actually copy this line! -->
     <!--[if lt IE 9]><script src="/static/js/ie8-responsive-file-warning.js"></script><![endif]-->
 


### PR DESCRIPTION
Fixed ASCII errors by using UTF-8 encoding on file names. This fixed issues I was getting in downloading files with Chinese/Japanese characters in the titles. Also set log to ERROR and disabled the Werkzeug messages that were flooding my terminal.